### PR TITLE
Fix typo in docs/index.mdx

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -15,7 +15,7 @@ hero:
       link: https://twitter.com/VRENGAssoc
       icon: "x.com"
       variant: secondary
-    - text: Disclrd
+    - text: Discord
       link: https://discord.gg/zaTjFtDRP7
       icon: discord
       variant: secondary


### PR DESCRIPTION
`Disclrd`を`Discord`に修正しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated a text link from "Disclrd" to "Discord" in the hero section of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->